### PR TITLE
update README; use ISO 8601 timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A sound-activated audio recorder with support for uploading audio to [Broadcasti
 - To upload recorded audio files to Broadcastify Calls, enter information received from Broadcastify support
   - API key goes in the API key field
   - SID goes in the System ID field
-  - Slot goes in the Slod ID filed (default to 1 if no Slot ID is provided)
+  - Slot goes in the Slot ID field (defaults to 1 if no Slot ID is provided)
 - To upload recorded audio files to rdio-scanner, enter information for the desired rdio-scanner instance
   - URL of the rdio-scanner api (for example:  192.168.1.138:3000/api/call-upload
   - rdio-scanner API key (create using the rdio-scanner admin interface)
@@ -18,7 +18,7 @@ A sound-activated audio recorder with support for uploading audio to [Broadcasti
 - When audio is detected above the Audio Squelch level, audio will be recorded until two seconds of silence is detected.  Once the recording ends, an MP3 file will be created.  
   - If valid Broadcastify Calls credentials are entered, the MP3 file will be uploaded to that system.  
   - If valid rdio-scanner credentials are entered, the MP3 file will be uploaded to that system.
-  - If the "Save Audio Files" option is selected, the recordings will be saved to the /audiosave subdirectory.   Otherwise, the MP3 will be deleted.  The filename will be the UNIX timestamp of when the recording was started. 
+  - If the "Save Audio Files" option is selected, the recordings will be saved to the ~/audiosave/ subdirectory.  Otherwise, the MP3 will be deleted.  The filename will be the UNIX timestamp of when the recording was started. 
 - There is a two-minute timeout timer.  If a recording exceeds two minutes (stuck squelch, noise, etc.) recording will stop, an error will be displayed, and no further activity will take place until the input audio goes below the Audio Squelch threshold, at which time normal operation will resume.
 - Multiple instances can be run at the same time to capture audio from multiple recievers.  Create a different directory for each instance.  Each directory must have a config.cfg file.  On Windows, each directory should also have a copy of ffmpeg.exe or ffmpeg.exe must be added to the system path.  
 - Something not working?  Check the log.txt file for errors and create an Issue here if needed.
@@ -28,9 +28,9 @@ A sound-activated audio recorder with support for uploading audio to [Broadcasti
 - Uncompress the downloaded ZIP file
 - Run the EXE
 
-## Raspberry Pi executable binary (compiled for Raspbian Buster)
+## Raspberry Pi executable binary (compiled for Raspbian Buster; seems to work perfectly well in Raspbian Bullseye)
 [TGZ Download](https://radioetcetera.site/radioetcetera/files/voxcall.tgz)
-- Use a cheap USB sound card as the audio input - the Pi does not come with an audio input
+- Use a cheap USB sound card as the audio input — the Pi does not come with an audio input
 - Download using link above or via `curl -O https://radioetcetera.site/radioetcetera/files/voxcall.tgz`
 - `tar zxf voxcall.tgz` to uncompress
 - Install pulseaudio:
@@ -39,6 +39,7 @@ A sound-activated audio recorder with support for uploading audio to [Broadcasti
   - `sudo apt-get install ffmpeg`
 - To run:
   - `/home/pi/voxcall/voxcall`
+  - Select “Pulse” as the Audio Input Device, not the actual USB sound card. (Yes, it’s counter-intuitive, but the pulse audio sound system does the sample rate conversion so that voxcall can get the audio from the sound card at the rate that it needs.)
 
 
 

--- a/voxcall.py
+++ b/voxcall.py
@@ -42,7 +42,7 @@ logger.addHandler(fh)
 
 
 #record_threshold = 800
-vox_silence_time = 2
+vox_silence_time = 2            # Reset twice, below, based on settings in "Section1" and "Section" of config file
 mp3_bitrate = 32000
 start_minimized = 0
 rectime = .1
@@ -500,14 +500,14 @@ def saveconfigdata():
 		cfgfile = open('config.cfg','w')
 		config.set('Section1','audio_dev_index',str(input_device_indices[input_device.get()]))
 		config.set('Section1','record_threshold',str(record_threshold.get()))
-		config.set('Section1','vox_silence_time',str(vox_silence_time))
+		config.set('Section1','vox_silence_time',str(vox_silence_time)) # See [1], below
 		config.set('Section1','in_channel',in_channel.get())
 		config.set('Section1','BCFY_SystemId',BCFY_SystemId.get())
 		config.set('Section1','RadioFreq',RadioFreq.get())
 		config.set('Section1','BCFY_APIkey',BCFY_APIkey.get())
 		config.set('Section1','BCFY_SlotId',BCFY_SlotId.get())
 		config.set('Section1','saveaudio',str(saveaudio.get()))
-		config.set('Section1','vox_silence_time',str(vox_silence_time))
+		config.set('Section1','vox_silence_time',str(vox_silence_time)) # [1] Why is this set a 2nd time?
 		config.set('Section1','RDIO_APIkey',RDIO_APIkey.get())
 		config.set('Section1','RDIO_APIurl',RDIO_APIurl.get())
 		config.set('Section1','RDIO_system',RDIO_system.get())

--- a/voxcall.py
+++ b/voxcall.py
@@ -408,7 +408,7 @@ def start():
 			quiet_samples=0
 			total_samples = 0
 			alldata = bytearray()
-			logger.debug("Waiting for Silence " + time.strftime('%H:%M:%S on %m/%d/%y'))
+			logger.debug("Waiting for Silence " + time.strftime('%Y-%m-%d %H:%M:%S'))
 			if root != '':
 				statvar.set("Recording")
 				StatLabel.config(fg='green')
@@ -445,7 +445,7 @@ def start():
 					else:
 						quiet_samples = 0
 				total_samples = total_samples+1
-			logger.debug("Done recording " + time.strftime('%H:%M:%S on %m/%d/%y'))
+			logger.debug("Done recording " + time.strftime('%Y-%m-%d %H:%M:%S'))
 			if int(vox_silence_time*-(1/rectime)) > 0:
 				alldata = alldata[:int(vox_silence_time*-round(1/rectime))]
 			data = frombuffer(alldata, dtype=short)  #convert from string to list to separate channels
@@ -459,24 +459,25 @@ def start():
 			#convert back to binary to write to WAV later
 			data = chararray.tostring(array(data))
 			# write data to WAVE file
-			fname = str(round(time.time())) + "-" + str(BCFY_SlotId.get()) + ".wav"
-			WAVE_OUTPUT_FILENAME = fname
+			BCFYsuffix = '' if str(BCFY_SlotId.get()) == '' else "-" + str(BCFY_SlotId.get())
+			fname = time.strftime('%Y-%m-%dT%H:%M:%S') + BCFYsuffix + ".wav"
+			furl = 'file:' + fname
 
-			wf = wave.open(WAVE_OUTPUT_FILENAME, 'wb')
+			wf = wave.open( fname, 'wb')
 			wf.setnchannels(1)
 			wf.setsampwidth(pyaudio.PyAudio().get_sample_size(FORMAT))
 			wf.setframerate(RATE)
 			wf.writeframes(data)
 			wf.close()
-			logger.debug("done writing WAV "  + time.strftime('%H:%M:%S on %m/%d/%y'))
+			logger.debug("done writing WAV "  + time.strftime('%Y-%m-%d %H:%M:%S'))
 			try:			
 				logger.debug(fname)
 				try:
 					flags = subprocess.CREATE_NO_WINDOW
 				except:
 					flags = 0
-				subprocess.call(["ffmpeg","-y","-i",fname,"-b:a",str(mp3_bitrate),"-ar","22050",fname.replace('.wav','.mp3')],creationflags=flags)
-				logger.debug("done converting to MP3 " + time.strftime('%H:%M:%S on %m/%d/%y'))				#use ffmpeg.exe 
+				subprocess.call(["ffmpeg","-y","-i",furl,"-b:a",str(mp3_bitrate),"-ar","22050",furl.replace('.wav','.mp3')],creationflags=flags)
+				logger.debug("done converting to MP3 " + time.strftime('%Y-%m-%d %H:%M:%S'))				#use ffmpeg.exe 
 				os.remove(fname)
 			except:
 				#exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -486,7 +487,7 @@ def start():
 			_thread.start_new_thread(upload_rdio,(fname.replace('.wav','.mp3'),))
 			last_API_attempt = time.time()
 			logger.debug("duration: " + str(duration) + " sec")
-			logger.debug("waiting for audio " + time.strftime('%H:%M:%S on %m/%d/%y'))
+			logger.debug("waiting for audio " + time.strftime('%Y-%m-%d %H:%M:%S'))
 			if root != '':
 				statvar.set("Waiting For Audio")
 				StatLabel.config(fg='blue')


### PR DESCRIPTION
**README**

- Fix a few minor typos
- Be more explicit about output directory path
- Mention that it works in R.Pi Bullseye
- Include instruction to set input to **pulse** when using USB on R.Pi

**code**

- Use ISO 8601 timestamps both in messages (as date & time) and as timestamp of output .mp3 file (as dateTime).
- Also comment on resetting of vox_silence_time, mostly as a way to ask a question.

Note: I am _not_ a Python programmer, so code should probably be checked and tested kinda carefully.